### PR TITLE
Add ev connector types to station show

### DIFF
--- a/app/serializers/station_serializer.rb
+++ b/app/serializers/station_serializer.rb
@@ -1,4 +1,4 @@
 class StationSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :name, :api_id, :status, :hours, :ev_network, :street_address, :city, :state, :zip_code, :accepted_payments, :hourly_weather
+  attributes :name, :api_id, :status, :hours, :ev_network, :ev_connector_types, :street_address, :city, :state, :zip_code, :accepted_payments, :hourly_weather
 end

--- a/spec/requests/api/v1/stations/show_spec.rb
+++ b/spec/requests/api/v1/stations/show_spec.rb
@@ -25,11 +25,13 @@ RSpec.describe "Display a single station" do
       expect(response_body[:data][:type]).to be_a String
       expect(response_body[:data][:attributes]).to be_a Hash
 
+      expect(new_station.size).to eq(12)
       expect(new_station).to have_key(:name)
       expect(new_station).to have_key(:api_id)
       expect(new_station).to have_key(:status)
       expect(new_station).to have_key(:hours)
       expect(new_station).to have_key(:ev_network)
+      expect(new_station).to have_key(:ev_connector_types)
       expect(new_station).to have_key(:street_address)
       expect(new_station).to have_key(:city)
       expect(new_station).to have_key(:state)


### PR DESCRIPTION
### ❓ Feature or Problem:
 <!-- What needed changed? bug? refactor? feature? Please describe the problem you're trying to solve -->
- Add ev_connector_types to station show (It was omitted from serializer)
### 💡 Solution:
<!-- how are you solving this simply and elegantly? Describe if necessary or check corresponding boxes -->
* [ ] New feature
* [ ] Bug fix
* [ ] Refactor
* [x] Other

### 🤔 Testing:

* [x] Wrote new tests
* [x] Successfully ran tests
* [x] All new and existing tests passed

### ✅ Checklist:

* [x] I have reviewed my code
* [ ] My code has no unused/commented out code
* [ ] I have commented my code for hard-to-understand areas
* [x] I have fully tested my code
* [x] I have made corresponding changes to the documentation

--------------------------------------------------------------------------------
**🦥 Test Coverage:**

* [ ] < 90%
* [ ] 90-99%
* [x] 100%
